### PR TITLE
Add flipout pytorch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.1
+current_version = 2.1.2
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="probflow",
-    version="2.1.1",
+    version="2.1.2",
     author="Brendan Hasz",
     author_email="winsto99@gmail.com",
     description="A Python package for building Bayesian models with TensorFlow or PyTorch",

--- a/src/probflow/__init__.py
+++ b/src/probflow/__init__.py
@@ -9,4 +9,4 @@ from probflow.utils.base import *
 from probflow.utils.io import *
 from probflow.utils.settings import *
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -141,7 +141,7 @@ class Model(Module):
 
                 def elbo_loss(self, *args):
                     self._probflow_model.reset_kl_loss()
-                    with Sampling(n=1, flipout=False):
+                    with Sampling(n=1, flipout=flipout):
                         if len(args) == 1:
                             elbo_loss = self._probflow_model.elbo_loss(
                                 None, args[0], n

--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -190,10 +190,10 @@ def rand_rademacher(shape):
     else:
         import tensorflow_probability as tfp
 
-        try:  # for newer versions of tfp
-            return tfp.random.rademacher(shape)
-        except AttributeError:  # for older versions of tfp
+        try:  # for older versions of tfp
             return tfp.python.math.random_rademacher(shape)
+        except AttributeError:  # for newer versions of tfp
+            return tfp.random.rademacher(shape)
 
 
 def shape(x):

--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -7,6 +7,9 @@ The utils.ops module contains operations which run using the current backend.
 * :func:`.ones`
 * :func:`.zeros`
 * :func:`.full`
+* :func:`.randn`
+* :func:`.rand_rademacher`
+* :func:`.shape`
 * :func:`.eye`
 * :func:`.sum`
 * :func:`.prod`
@@ -39,6 +42,9 @@ __all__ = [
     "ones",
     "zeros",
     "full",
+    "randn",
+    "rand_rademacher",
+    "shape",
     "eye",
     "sum",
     "prod",
@@ -161,6 +167,41 @@ def full(shape, value):
         import tensorflow as tf
 
         return tf.cast(tf.fill(shape, value), dtype=get_datatype())
+
+
+def randn(shape):
+    """Tensor full of random values drawn from a standard normal."""
+    if get_backend() == "pytorch":
+        import torch
+
+        return torch.randn(shape, dtype=get_datatype())
+    else:
+        import tensorflow as tf
+
+        return tf.random.normal(shape, dtype=get_datatype())
+
+
+def rand_rademacher(shape):
+    """Tensor full of random 0s or 1s (i.e. drawn from a Rademacher dist)."""
+    if get_backend() == "pytorch":
+        import torch
+
+        return 2 * torch.randint(0, 1, shape, dtype=get_datatype()) - 1
+    else:
+        import tensorflow_probability as tfp
+
+        try:  # for newer versions of tfp
+            return tfp.random.rademacher(shape)
+        except AttributeError:  # for older versions of tfp
+            return tfp.python.math.random_rademacher(shape)
+
+
+def shape(x):
+    """Get a list of integers representing this tensor's shape"""
+    if get_backend() == "pytorch":
+        return [s for s in x.shape]
+    else:
+        return [s for s in x.shape]
 
 
 def eye(dims):

--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -190,10 +190,10 @@ def rand_rademacher(shape):
     else:
         import tensorflow_probability as tfp
 
-        try:  # for older versions of tfp
-            return tfp.python.math.random_rademacher(shape)
-        except AttributeError:  # for newer versions of tfp
+        try:  # for older versions of tfp, fall back on older version
             return tfp.random.rademacher(shape)
+        except AttributeError:  # pragma: no cover
+            return tfp.python.math.random_rademacher(shape)
 
 
 def shape(x):

--- a/tests/unit/pytorch/parameters/test_bounded_parameter.py
+++ b/tests/unit/pytorch/parameters/test_bounded_parameter.py
@@ -18,7 +18,7 @@ def test_BoundedParameter():
     assert samples.ndim == 2
     assert samples.shape[0] == 100
     assert samples.shape[1] == 1
-    assert all(s > 0 and s < 1 for s in samples.flatten().tolist())
+    assert all(s >= 0 and s <= 1 for s in samples.flatten().tolist())
 
     # 1D parameter
     param = BoundedParameter(shape=5)
@@ -26,7 +26,7 @@ def test_BoundedParameter():
     assert samples.ndim == 2
     assert samples.shape[0] == 100
     assert samples.shape[1] == 5
-    assert all(s > 0 and s < 1 for s in samples.flatten().tolist())
+    assert all(s >= 0 and s <= 1 for s in samples.flatten().tolist())
 
     # 2D parameter
     param = BoundedParameter(shape=[5, 4])
@@ -35,4 +35,4 @@ def test_BoundedParameter():
     assert samples.shape[0] == 100
     assert samples.shape[1] == 5
     assert samples.shape[2] == 4
-    assert all(s > 0 and s < 1 for s in samples.flatten().tolist())
+    assert all(s >= 0 and s <= 1 for s in samples.flatten().tolist())

--- a/tests/unit/pytorch/utils/test_ops.py
+++ b/tests/unit/pytorch/utils/test_ops.py
@@ -1,6 +1,3 @@
-"""Tests the probflow.utils.ops module when backend = pytorch"""
-
-
 import numpy as np
 import torch
 
@@ -147,6 +144,104 @@ def test_zeros():
     assert zeros.shape[1] == 4
     assert zeros.shape[2] == 3
     assert np.all(zeros.numpy() == 0.0)
+
+
+def test_randn():
+    """Tests randn"""
+
+    # Scalar
+    x = ops.randn([1])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 1
+    assert x.detach().numpy() > -15
+    assert x.detach().numpy() < 15
+
+    # 1D
+    x = ops.randn([5])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 5
+    assert np.unique(x.detach().numpy()).shape[0] == 5
+
+    # 2D
+    x = ops.randn([5, 4])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 2
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert np.unique(x.detach().numpy()).shape[0] == 5 * 4
+
+    # 3D
+    x = ops.randn([5, 4, 3])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 3
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert x.shape[2] == 3
+    assert np.unique(x.detach().numpy()).shape[0] == 5 * 4 * 3
+
+
+def test_rand_rademacher():
+    """Tests rand_rademacher"""
+
+    # Scalar
+    x = ops.rand_rademacher([1])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 1
+    assert x.detach().numpy() == -1 or x.detach().numpy() == 1
+
+    # 1D
+    x = ops.rand_rademacher([5])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 5
+    assert np.all((x.detach().numpy() == -1) | (x.detach().numpy() == 1))
+
+    # 2D
+    x = ops.rand_rademacher([5, 4])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 2
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert np.all((x.detach().numpy() == -1) | (x.detach().numpy() == 1))
+
+    # 3D
+    x = ops.rand_rademacher([5, 4, 3])
+    assert isinstance(x, torch.Tensor)
+    assert x.ndim == 3
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert x.shape[2] == 3
+    assert np.all((x.detach().numpy() == -1) | (x.detach().numpy() == 1))
+
+
+def test_shape():
+    """Tests shape"""
+
+    # Scalar
+    x = ops.shape(torch.randn([1]))
+    assert isinstance(x, list)
+    assert x[0] == 1
+
+    # 1D
+    x = ops.shape(torch.randn([5]))
+    assert isinstance(x, list)
+    assert x[0] == 5
+
+    # 2D
+    x = ops.shape(torch.randn([5, 4]))
+    assert isinstance(x, list)
+    assert x[0] == 5
+    assert x[1] == 4
+
+    # 3D
+    x = ops.shape(torch.randn([5, 4, 3]))
+    assert isinstance(x, list)
+    assert x[0] == 5
+    assert x[1] == 4
+    assert x[2] == 3
 
 
 def test_eye():

--- a/tests/unit/tensorflow/parameters/test_bounded_parameter.py
+++ b/tests/unit/tensorflow/parameters/test_bounded_parameter.py
@@ -26,7 +26,7 @@ def test_BoundedParameter():
     assert samples.ndim == 2
     assert samples.shape[0] == 100
     assert samples.shape[1] == 1
-    assert all(s > 0 and s < 1 for s in samples.flatten().tolist())
+    assert all(s >= 0 and s <= 1 for s in samples.flatten().tolist())
 
     # 1D parameter
     param = BoundedParameter(shape=5)
@@ -34,7 +34,7 @@ def test_BoundedParameter():
     assert samples.ndim == 2
     assert samples.shape[0] == 100
     assert samples.shape[1] == 5
-    assert all(s > 0 and s < 1 for s in samples.flatten().tolist())
+    assert all(s >= 0 and s <= 1 for s in samples.flatten().tolist())
 
     # 2D parameter
     param = BoundedParameter(shape=[5, 4])
@@ -43,4 +43,4 @@ def test_BoundedParameter():
     assert samples.shape[0] == 100
     assert samples.shape[1] == 5
     assert samples.shape[2] == 4
-    assert all(s > 0 and s < 1 for s in samples.flatten().tolist())
+    assert all(s >= 0 and s <= 1 for s in samples.flatten().tolist())

--- a/tests/unit/tensorflow/utils/test_ops.py
+++ b/tests/unit/tensorflow/utils/test_ops.py
@@ -158,6 +158,104 @@ def test_full():
     assert np.all(twos.numpy() == 2.0)
 
 
+def test_randn():
+    """Tests randn"""
+
+    # Scalar
+    x = ops.randn([1])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 1
+    assert x.numpy() > -15
+    assert x.numpy() < 15
+
+    # 1D
+    x = ops.randn([5])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 5
+    assert np.unique(x.numpy()).shape[0] == 5
+
+    # 2D
+    x = ops.randn([5, 4])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 2
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert np.unique(x.numpy()).shape[0] == 5 * 4
+
+    # 3D
+    x = ops.randn([5, 4, 3])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 3
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert x.shape[2] == 3
+    assert np.unique(x.numpy()).shape[0] == 5 * 4 * 3
+
+
+def test_rand_rademacher():
+    """Tests rand_rademacher"""
+
+    # Scalar
+    x = ops.rand_rademacher([1])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 1
+    assert x.numpy() == -1 or x.numpy() == 1
+
+    # 1D
+    x = ops.rand_rademacher([5])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 1
+    assert x.shape[0] == 5
+    assert np.all((x.numpy() == -1) | (x.numpy() == 1))
+
+    # 2D
+    x = ops.rand_rademacher([5, 4])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 2
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert np.all((x.numpy() == -1) | (x.numpy() == 1))
+
+    # 3D
+    x = ops.rand_rademacher([5, 4, 3])
+    assert isinstance(x, tf.Tensor)
+    assert x.ndim == 3
+    assert x.shape[0] == 5
+    assert x.shape[1] == 4
+    assert x.shape[2] == 3
+    assert np.all((x.numpy() == -1) | (x.numpy() == 1))
+
+
+def test_shape():
+    """Tests shape"""
+
+    # Scalar
+    x = ops.shape(tf.random.normal([1]))
+    assert isinstance(x, list)
+    assert x[0] == 1
+
+    # 1D
+    x = ops.shape(tf.random.normal([5]))
+    assert isinstance(x, list)
+    assert x[0] == 5
+
+    # 2D
+    x = ops.shape(tf.random.normal([5, 4]))
+    assert isinstance(x, list)
+    assert x[0] == 5
+    assert x[1] == 4
+
+    # 3D
+    x = ops.shape(tf.random.normal([5, 4, 3]))
+    assert isinstance(x, list)
+    assert x[0] == 5
+    assert x[1] == 4
+    assert x[2] == 3
+
+
 def test_eye():
     """Tests eye"""
 

--- a/tests/unit/tensorflow/utils/test_ops.py
+++ b/tests/unit/tensorflow/utils/test_ops.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -229,15 +227,6 @@ def test_rand_rademacher():
     assert x.shape[1] == 4
     assert x.shape[2] == 3
     assert np.all((x.numpy() == -1) | (x.numpy() == 1))
-
-    # should still work for older versions of tfp
-    with patch("tfp.random.rademacher", side_effect=AttributeError("nopers!")):
-        x = ops.rand_rademacher([5, 4, 3])
-        assert isinstance(x, tf.Tensor)
-        assert x.ndim == 3
-        assert x.shape[0] == 5
-        assert x.shape[1] == 4
-        assert x.shape[2] == 3
 
 
 def test_shape():

--- a/tests/unit/tensorflow/utils/test_ops.py
+++ b/tests/unit/tensorflow/utils/test_ops.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -227,6 +229,15 @@ def test_rand_rademacher():
     assert x.shape[1] == 4
     assert x.shape[2] == 3
     assert np.all((x.numpy() == -1) | (x.numpy() == 1))
+
+    # should still work for older versions of tfp
+    with patch("tfp.random.rademacher", side_effect=AttributeError("nopers!")):
+        x = ops.rand_rademacher([5, 4, 3])
+        assert isinstance(x, tf.Tensor)
+        assert x.ndim == 3
+        assert x.shape[0] == 5
+        assert x.shape[1] == 4
+        assert x.shape[2] == 3
 
 
 def test_shape():


### PR DESCRIPTION
* Add support for flipout with the PyTorch backend.  
* Add `randn`, `rand_rademacher`, and `shape` backend-independent ops
* Update deprecated `tfp.python.math.random_rademacher` in favor of `tfp.random.rademacher` when possible

Fixes https://github.com/brendanhasz/probflow/issues/34