### PR TITLE
Multiple MC samples

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.2
+current_version = 2.2.0
 
 [bumpversion:file:setup.py]
 

--- a/docs/user_guide/fitting.rst
+++ b/docs/user_guide/fitting.rst
@@ -12,6 +12,28 @@ TODO:
 * passing a pandas dataframe
 * passing a DataGenerator to fit
 
+Using multiple MC samples per batch
+-----------------------------------
+
+By default, ProbFlow uses only one Monte Carlo sample from the variational
+posteriors per batch.  However, you can use more by passing the `n_mc` keyword
+argument to :meth:`.Model.fit`.  For example, to use 10 MC samples during
+training:
+
+.. code-block:: python3
+
+    model = pf.LinearRegression(x.shape[1])
+
+    model.fit(x, y, n_mc=10)
+
+Using more MC samples will cause the fit to take longer, but the parameter
+optimization will be much more stable because the variance of the gradients
+will be less.
+
+Note that :class:`.Dense` modules, which use the flipout estimator by default,
+will not use flipout when `n_mc` > 1.
+
+
 Backend graph optimization during fitting
 -----------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="probflow",
-    version="2.1.2",
+    version="2.2.0",
     author="Brendan Hasz",
     author_email="winsto99@gmail.com",
     description="A Python package for building Bayesian models with TensorFlow or PyTorch",

--- a/src/probflow/__init__.py
+++ b/src/probflow/__init__.py
@@ -9,4 +9,4 @@ from probflow.utils.base import *
 from probflow.utils.io import *
 from probflow.utils.settings import *
 
-__version__ = "2.1.2"
+__version__ = "2.2.0"

--- a/src/probflow/models/categorical_model.py
+++ b/src/probflow/models/categorical_model.py
@@ -90,7 +90,7 @@ class CategoricalModel(Model):
         N = samples.shape[1]
         if samples.ndim > 2 and any(e > 1 for e in samples.shape[2:]):
             raise NotImplementedError(
-                "only categorical dependent variables " "are supported"
+                "only categorical dependent variables are supported"
             )
         else:
             samples = samples.reshape([Ns, N])

--- a/src/probflow/models/continuous_model.py
+++ b/src/probflow/models/continuous_model.py
@@ -291,7 +291,7 @@ class ContinuousModel(Model):
         N = samples.shape[1]
         if samples.ndim > 2 and any(e > 1 for e in samples.shape[2:]):
             raise NotImplementedError(
-                "only scalar dependent variables are " "supported"
+                "only scalar dependent variables are supported"
             )
         else:
             samples = samples.reshape([Ns, N])
@@ -364,7 +364,7 @@ class ContinuousModel(Model):
         # Independent variable must be scalar
         if samples.ndim > 2 and any(e > 1 for e in samples.shape[2:]):
             raise NotImplementedError(
-                "only scalar dependent variables are " "supported"
+                "only scalar dependent variables are supported"
             )
 
         # Reshape

--- a/src/probflow/modules/dense.py
+++ b/src/probflow/modules/dense.py
@@ -2,13 +2,21 @@ import probflow.utils.ops as O
 from probflow.modules.module import Module
 from probflow.parameters import DeterministicParameter, Parameter
 from probflow.utils.casting import to_tensor
-from probflow.utils.settings import get_flipout
+from probflow.utils.settings import get_flipout, get_samples
 
 
 class Dense(Module):
     """Dense neural network layer.
 
     TODO
+
+    .. admonition:: Will not use flipout when n_mc>1
+
+        Note that this module uses the flipout estimator by default, but will
+        not use the flipout estimator when we are taking multiple monte carlo
+        samples per batch (when `n_mc` > 1).  See :meth:`.Model.fit` for more
+        info on setting the value of `n_mc`.
+
 
     Parameters
     ----------
@@ -74,7 +82,13 @@ class Dense(Module):
         x = to_tensor(x)
 
         # Using the Flipout estimator
-        if get_flipout() and self.flipout and self.probabilistic:
+        if (
+            get_flipout()
+            and self.flipout
+            and self.probabilistic
+            and get_samples() is not None
+            and get_samples() == 1
+        ):
 
             # Flipout-estimated weight samples
             s = O.rand_rademacher(O.shape(x))

--- a/tests/unit/pytorch/applications/test_dense_classifier.py
+++ b/tests/unit/pytorch/applications/test_dense_classifier.py
@@ -3,6 +3,14 @@ import numpy as np
 from probflow.applications import DenseClassifier
 
 
+def get_multinomial_data(n, di, do):
+    x = np.random.randn(n, di).astype("float32")
+    w = np.random.randn(di, do).astype("float32")
+    b = np.random.randn(1, do).astype("float32")
+    y = np.argmax(x @ w + b, axis=1).astype("int32")
+    return x, y
+
+
 def test_DenseClassifier():
     """Tests probflow.applications.DenseClassifier"""
 
@@ -26,17 +34,45 @@ def test_MultinomialDenseClassifier():
     """Tests probflow.applications.DenseClassifier w/ >2 output classes"""
 
     # Data
-    x = np.random.randn(100, 5).astype("float32")
-    w = np.random.randn(5, 3).astype("float32")
-    b = np.random.randn(1, 3).astype("float32")
-    y = x @ w + b
-    y = np.argmax(y, axis=1).astype("int32")
+    x, y = get_multinomial_data(100, 5, 3)
 
     # Create the model
-    model = DenseClassifier([5, 20, 15, 3])
+    model = DenseClassifier([5, 10, 7, 3])
 
     # Fit the model
-    model.fit(x, y, batch_size=10, epochs=3)
+    model.fit(x, y, batch_size=25, epochs=3)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_DenseClassifier_multimc_eager():
+    """Tests DenseClassifier w/ n_mc>1 in eager mode"""
+
+    # Data
+    x, y = get_multinomial_data(100, 5, 3)
+
+    # Create the model
+    model = DenseClassifier([5, 10, 7, 3])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_DenseClassifier_multimc_noneager():
+    """Tests DenseClassifier w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    x, y = get_multinomial_data(100, 5, 3)
+
+    # Create the model
+    model = DenseClassifier([5, 10, 7, 3])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
 
     # Predictive functions
     model.predict(x)

--- a/tests/unit/pytorch/applications/test_dense_regression.py
+++ b/tests/unit/pytorch/applications/test_dense_regression.py
@@ -101,3 +101,69 @@ def test_DenseRegression_multivariate():
     assert preds.shape[0] == 13
     assert preds.shape[1] == 11
     assert preds.shape[2] == Do
+
+
+def test_DenseRegression_multimc_eager():
+    """Tests DenseRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = DenseRegression([Di, 16, Do])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do
+
+
+def test_DenseRegression_multimc_noneager():
+    """Tests DenseRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = DenseRegression([Di, 16, Do])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do

--- a/tests/unit/pytorch/applications/test_linear_regression.py
+++ b/tests/unit/pytorch/applications/test_linear_regression.py
@@ -101,3 +101,69 @@ def test_LinearRegression_multivariate():
     assert preds.shape[0] == 13
     assert preds.shape[1] == 11
     assert preds.shape[2] == Do
+
+
+def test_LinearRegression_multimc_eager():
+    """Tests inearRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = LinearRegression(Di, d_o=Do)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do
+
+
+def test_LinearRegression_multimc_noneager():
+    """Tests inearRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = LinearRegression(Di, d_o=Do)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do

--- a/tests/unit/pytorch/applications/test_logistic_regression.py
+++ b/tests/unit/pytorch/applications/test_logistic_regression.py
@@ -40,3 +40,43 @@ def test_MultinomialLogisticRegression():
 
     # Predictive functions
     model.predict(x)
+
+
+def test_LogisticRegression_multiMC_eager():
+    """Tests LinearRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 3).astype("float32")
+    b = np.random.randn(1, 3).astype("float32")
+    y = x @ w + b
+    y = np.argmax(y, axis=1).astype("int32")
+
+    # Create the model
+    model = LogisticRegression(d=5, k=3)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_LogisticRegression_multiMC_noneager():
+    """Tests LinearRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 3).astype("float32")
+    b = np.random.randn(1, 3).astype("float32")
+    y = x @ w + b
+    y = np.argmax(y, axis=1).astype("int32")
+
+    # Create the model
+    model = LogisticRegression(d=5, k=3)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    model.predict(x)

--- a/tests/unit/pytorch/applications/test_poisson_regression.py
+++ b/tests/unit/pytorch/applications/test_poisson_regression.py
@@ -20,3 +20,41 @@ def test_PoissonRegression():
 
     # Predictive functions
     model.predict(x)
+
+
+def test_PoissonRegression_multiMC_eager():
+    """Tests PoissonRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 1).astype("float32")
+    y = x @ w + 1
+    y = np.random.poisson(lam=np.exp(y)).astype("float32")
+
+    # Create the model
+    model = PoissonRegression(5)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_PoissonRegression_multiMC_noneager():
+    """Tests PoissonRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 1).astype("float32")
+    y = x @ w + 1
+    y = np.random.poisson(lam=np.exp(y)).astype("float32")
+
+    # Create the model
+    model = PoissonRegression(5)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    model.predict(x)

--- a/tests/unit/tensorflow/applications/test_dense_classifier.py
+++ b/tests/unit/tensorflow/applications/test_dense_classifier.py
@@ -3,6 +3,14 @@ import numpy as np
 from probflow.applications import DenseClassifier
 
 
+def get_multinomial_data(n, di, do):
+    x = np.random.randn(n, di).astype("float32")
+    w = np.random.randn(di, do).astype("float32")
+    b = np.random.randn(1, do).astype("float32")
+    y = np.argmax(x @ w + b, axis=1).astype("int32")
+    return x, y
+
+
 def test_DenseClassifier():
     """Tests probflow.applications.DenseClassifier"""
 
@@ -26,17 +34,45 @@ def test_MultinomialDenseClassifier():
     """Tests probflow.applications.DenseClassifier w/ >2 output classes"""
 
     # Data
-    x = np.random.randn(100, 5).astype("float32")
-    w = np.random.randn(5, 3).astype("float32")
-    b = np.random.randn(1, 3).astype("float32")
-    y = x @ w + b
-    y = np.argmax(y, axis=1).astype("int32")
+    x, y = get_multinomial_data(100, 5, 3)
 
     # Create the model
-    model = DenseClassifier([5, 20, 15, 3])
+    model = DenseClassifier([5, 10, 7, 3])
 
     # Fit the model
-    model.fit(x, y, batch_size=10, epochs=3)
+    model.fit(x, y, batch_size=25, epochs=3)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_DenseClassifier_multimc_eager():
+    """Tests DenseClassifier w/ n_mc>1 in eager mode"""
+
+    # Data
+    x, y = get_multinomial_data(100, 5, 3)
+
+    # Create the model
+    model = DenseClassifier([5, 10, 7, 3])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_DenseClassifier_multimc_noneager():
+    """Tests DenseClassifier w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    x, y = get_multinomial_data(100, 5, 3)
+
+    # Create the model
+    model = DenseClassifier([5, 10, 7, 3])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
 
     # Predictive functions
     model.predict(x)

--- a/tests/unit/tensorflow/applications/test_dense_regression.py
+++ b/tests/unit/tensorflow/applications/test_dense_regression.py
@@ -101,3 +101,69 @@ def test_DenseRegression_multivariate():
     assert preds.shape[0] == 13
     assert preds.shape[1] == 11
     assert preds.shape[2] == Do
+
+
+def test_DenseRegression_multimc_eager():
+    """Tests DenseRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = DenseRegression([Di, 16, Do])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do
+
+
+def test_DenseRegression_multimc_noneager():
+    """Tests DenseRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = DenseRegression([Di, 16, Do])
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do

--- a/tests/unit/tensorflow/applications/test_linear_regression.py
+++ b/tests/unit/tensorflow/applications/test_linear_regression.py
@@ -101,3 +101,69 @@ def test_LinearRegression_multivariate():
     assert preds.shape[0] == 13
     assert preds.shape[1] == 11
     assert preds.shape[2] == Do
+
+
+def test_LinearRegression_multimc_eager():
+    """Tests inearRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = LinearRegression(Di, d_o=Do)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do
+
+
+def test_LinearRegression_multimc_noneager():
+    """Tests inearRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    N = 100
+    Di = 7
+    Do = 3
+    x = np.random.randn(N, Di).astype("float32")
+    w = np.random.randn(Di, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+
+    # Create the model
+    model = LinearRegression(Di, d_o=Do)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    preds = model.predict(x[:11, :])
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 2
+    assert preds.shape[0] == 11
+    assert preds.shape[1] == Do
+
+    # Predictive functions
+    preds = model.predictive_sample(x[:11, :], n=13)
+    assert isinstance(preds, np.ndarray)
+    assert preds.ndim == 3
+    assert preds.shape[0] == 13
+    assert preds.shape[1] == 11
+    assert preds.shape[2] == Do

--- a/tests/unit/tensorflow/applications/test_logistic_regression.py
+++ b/tests/unit/tensorflow/applications/test_logistic_regression.py
@@ -40,3 +40,43 @@ def test_MultinomialLogisticRegression():
 
     # Predictive functions
     model.predict(x)
+
+
+def test_LogisticRegression_multiMC_eager():
+    """Tests LinearRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 3).astype("float32")
+    b = np.random.randn(1, 3).astype("float32")
+    y = x @ w + b
+    y = np.argmax(y, axis=1).astype("int32")
+
+    # Create the model
+    model = LogisticRegression(d=5, k=3)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_LogisticRegression_multiMC_noneager():
+    """Tests LinearRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 3).astype("float32")
+    b = np.random.randn(1, 3).astype("float32")
+    y = x @ w + b
+    y = np.argmax(y, axis=1).astype("int32")
+
+    # Create the model
+    model = LogisticRegression(d=5, k=3)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    model.predict(x)

--- a/tests/unit/tensorflow/applications/test_poisson_regression.py
+++ b/tests/unit/tensorflow/applications/test_poisson_regression.py
@@ -20,3 +20,41 @@ def test_PoissonRegression():
 
     # Predictive functions
     model.predict(x)
+
+
+def test_PoissonRegression_multiMC_eager():
+    """Tests PoissonRegression w/ n_mc>1 in eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 1).astype("float32")
+    y = x @ w + 1
+    y = np.random.poisson(lam=np.exp(y)).astype("float32")
+
+    # Create the model
+    model = PoissonRegression(5)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=True)
+
+    # Predictive functions
+    model.predict(x)
+
+
+def test_PoissonRegression_multiMC_noneager():
+    """Tests PoissonRegression w/ n_mc>1 in non-eager mode"""
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 1).astype("float32")
+    y = x @ w + 1
+    y = np.random.poisson(lam=np.exp(y)).astype("float32")
+
+    # Create the model
+    model = PoissonRegression(5)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=4, eager=False)
+
+    # Predictive functions
+    model.predict(x)

--- a/tests/unit/tensorflow/models/test_categorical_model.py
+++ b/tests/unit/tensorflow/models/test_categorical_model.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 import tensorflow_probability as tfp
 
 from probflow.distributions import Bernoulli
@@ -42,3 +43,32 @@ def test_CategoricalModel(plot):
     if plot:
         plt.title("should be one binary dist")
         plt.show()
+
+
+def test_ContinuousModel_multivariate():
+    """Tests probflow.models.CategoricalModel w/ multivariate target
+    I.e., a multitask learner.  Point is, pred_dist_plot shouldn't work then.
+    """
+
+    class MyModel(CategoricalModel):
+        def __init__(self):
+            self.weight = Parameter([5, 3], name="Weight")
+            self.bias = Parameter([1, 3], name="Bias")
+
+        def __call__(self, x):
+            return Bernoulli(x @ self.weight() + self.bias())
+
+    # Instantiate the model
+    model = MyModel()
+
+    # Data
+    x = np.random.randn(100, 5).astype("float32")
+    w = np.random.randn(5, 3).astype("float32")
+    y = ((x @ w) > 0).astype(int)
+
+    # Fit the model
+    model.fit(x, y, batch_size=50, epochs=2, lr=0.01, eager=True)
+
+    # pred_dist_plot should not work with nonscalar predictions
+    with pytest.raises(NotImplementedError):
+        model.pred_dist_plot(x[:10, :], n=10)

--- a/tests/unit/tensorflow/models/test_model.py
+++ b/tests/unit/tensorflow/models/test_model.py
@@ -760,3 +760,281 @@ def test_Model_nesting():
 
     # kl loss should be greater for outer model
     assert my_model.kl_loss().numpy() > my_model.module.kl_loss().numpy()
+
+
+def test_Model_multiple_mc_0d_eager():
+    """Fit probflow.model.Model w/ n_mc>1 to 0d data in eager mode"""
+
+    class MyModel(Model):
+        def __init__(self):
+            self.weight = Parameter(name="Weight")
+            self.bias = Parameter(name="Bias")
+            self.std = ScaleParameter(name="Std")
+
+        def __call__(self, x):
+            w = self.weight()
+            b = self.bias()
+            s = self.std()
+            m = x * w + b
+
+            # check shapes are as expected
+            if self._is_training:
+                assert x.ndim == 2
+                assert x.shape[0] == 1
+                assert x.shape[1] == 50
+                assert w.shape[0] == 5
+                assert w.shape[1] == 1
+                assert b.shape[0] == 5
+                assert b.shape[1] == 1
+                assert s.shape[0] == 5
+                assert s.shape[1] == 1
+                assert m.shape[0] == 5
+                assert m.shape[1] == 50
+            else:  # predicting
+                assert x.ndim == 1
+                assert x.shape[0] == 11
+                assert w.shape[0] == 1
+                assert b.shape[0] == 1
+                assert s.shape[0] == 1
+                assert m.shape[0] == 11
+
+            return Normal(m, s)
+
+    # Instantiate the model
+    model = MyModel()
+
+    # Fit the model
+    x = np.random.randn(100).astype("float32")
+    y = -x + 1
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=5, eager=True)
+
+    # Check predictions
+    p = model.predict(x[:11])
+    assert isinstance(p, np.ndarray)
+    assert p.ndim == 1
+    assert p.shape[0] == 11
+
+
+def test_Model_multiple_mc_0d_noneager():
+    """Fit probflow.model.Model w/ n_mc>1 to 0d data in non-eager mode"""
+
+    class MyModel(Model):
+        def __init__(self):
+            self.weight = Parameter(name="Weight")
+            self.bias = Parameter(name="Bias")
+            self.std = ScaleParameter(name="Std")
+
+        def __call__(self, x):
+            # can't check shapes b/c tracing it ignores this code
+            # so just check that it works
+            return Normal(x * self.weight() + self.bias(), self.std())
+
+    # Instantiate the model
+    model = MyModel()
+
+    # Fit the model
+    x = np.random.randn(100).astype("float32")
+    y = -x + 1
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=5, eager=False)
+
+    # Check predictions
+    p = model.predict(x[:11])
+    assert isinstance(p, np.ndarray)
+    assert p.ndim == 1
+    assert p.shape[0] == 11
+
+
+def test_Model_multiple_mc_1d_eager():
+    """Fit probflow.model.Model w/ n_mc>1 to vector data in eager mode"""
+
+    class MyModel(Model):
+        def __init__(self, d_in):
+            self.weight = Parameter([d_in, 1], name="Weight")
+            self.bias = Parameter([1, 1], name="Bias")
+            self.std = ScaleParameter([1, 1], name="Std")
+
+        def __call__(self, x):
+            w = self.weight()
+            b = self.bias()
+            s = self.std()
+            m = x @ w + b
+
+            # check shapes are as expected
+            if self._is_training:
+                assert x.ndim == 3
+                assert x.shape[0] == 1
+                assert x.shape[1] == 50
+                assert x.shape[2] == 3
+                assert w.shape[0] == 5
+                assert w.shape[1] == 3
+                assert w.shape[2] == 1
+                assert b.shape[0] == 5
+                assert b.shape[1] == 1
+                assert b.shape[2] == 1
+                assert s.shape[0] == 5
+                assert s.shape[1] == 1
+                assert s.shape[2] == 1
+                assert m.shape[0] == 5
+                assert m.shape[1] == 50
+                assert m.shape[2] == 1
+            else:  # predicting
+                assert x.ndim == 2
+                assert x.shape[0] == 11
+                assert x.shape[1] == 3
+                assert w.shape[0] == 3
+                assert w.shape[1] == 1
+                assert b.shape[0] == 1
+                assert b.shape[1] == 1
+                assert s.shape[0] == 1
+                assert s.shape[1] == 1
+                assert m.shape[0] == 11
+                assert m.shape[1] == 1
+
+            return Normal(m, s)
+
+    # Instantiate the model
+    model = MyModel(3)
+
+    # Fit the model
+    x = np.random.randn(100, 3).astype("float32")
+    w = np.random.randn(3, 1).astype("float32")
+    y = x @ w + 1
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=5, eager=True)
+
+    # Check predictions
+    p = model.predict(x[:11, :])
+    assert isinstance(p, np.ndarray)
+    assert p.ndim == 2
+    assert p.shape[0] == 11
+    assert p.shape[1] == 1
+
+
+def test_Model_multiple_mc_1d_noneager():
+    """Fit probflow.model.Model w/ n_mc>1 to vector data in non-eager mode"""
+
+    class MyModel(Model):
+        def __init__(self, d_in):
+            self.weight = Parameter([d_in, 1], name="Weight")
+            self.bias = Parameter([1, 1], name="Bias")
+            self.std = ScaleParameter([1, 1], name="Std")
+
+        def __call__(self, x):
+            w = self.weight()
+            b = self.bias()
+            s = self.std()
+            m = x @ w + b
+            return Normal(m, s)
+
+    # Instantiate the model
+    model = MyModel(3)
+
+    # Fit the model
+    x = np.random.randn(100, 3).astype("float32")
+    w = np.random.randn(3, 1).astype("float32")
+    y = x @ w + 1
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=5, eager=False)
+
+    # Check predictions
+    p = model.predict(x[:11, :])
+    assert isinstance(p, np.ndarray)
+    assert p.ndim == 2
+    assert p.shape[0] == 11
+    assert p.shape[1] == 1
+
+
+def test_Model_multiple_mc_2d_eager():
+    """Fit probflow.model.Model w/ n_mc>1 to multivar output in eager mode"""
+
+    class MyModel(Model):
+        def __init__(self, d_in, d_out):
+            self.weight = Parameter([d_in, d_out], name="Weight")
+            self.bias = Parameter([1, d_out], name="Bias")
+            self.std = ScaleParameter([1, d_out], name="Std")
+
+        def __call__(self, x):
+            w = self.weight()
+            b = self.bias()
+            s = self.std()
+            m = x @ w + b
+
+            # check shapes are as expected
+            if self._is_training:
+                assert x.ndim == 3
+                assert x.shape[0] == 1
+                assert x.shape[1] == 50
+                assert x.shape[2] == 4
+                assert w.shape[0] == 5
+                assert w.shape[1] == 4
+                assert w.shape[2] == 3
+                assert b.shape[0] == 5
+                assert b.shape[1] == 1
+                assert b.shape[2] == 3
+                assert s.shape[0] == 5
+                assert s.shape[1] == 1
+                assert s.shape[2] == 3
+                assert m.shape[0] == 5
+                assert m.shape[1] == 50
+                assert m.shape[2] == 3
+            else:  # predicting
+                assert x.ndim == 2
+                assert x.shape[0] == 11
+                assert x.shape[1] == 4
+                assert w.shape[0] == 4
+                assert w.shape[1] == 3
+                assert b.shape[0] == 1
+                assert b.shape[1] == 3
+                assert s.shape[0] == 1
+                assert s.shape[1] == 3
+                assert m.shape[0] == 11
+                assert m.shape[1] == 3
+
+            return Normal(m, s)
+
+    # Instantiate the model
+    model = MyModel(4, 3)
+
+    # Fit the model
+    x = np.random.randn(100, 4).astype("float32")
+    w = np.random.randn(4, 3).astype("float32")
+    y = x @ w + 1
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=5, eager=True)
+
+    # Check predictions
+    p = model.predict(x[:11, :])
+    assert isinstance(p, np.ndarray)
+    assert p.ndim == 2
+    assert p.shape[0] == 11
+    assert p.shape[1] == 3
+
+
+def test_Model_multiple_mc_2d_noneager():
+    """Fit probflow.model.Model w/ n_mc>1 to multivar output w noneager mode"""
+
+    class MyModel(Model):
+        def __init__(self, d_in, d_out):
+            self.weight = Parameter([d_in, d_out], name="Weight")
+            self.bias = Parameter([1, d_out], name="Bias")
+            self.std = ScaleParameter([1, d_out], name="Std")
+
+        def __call__(self, x):
+            w = self.weight()
+            b = self.bias()
+            s = self.std()
+            m = x @ w + b
+            return Normal(m, s)
+
+    # Instantiate the model
+    model = MyModel(4, 3)
+
+    # Fit the model
+    x = np.random.randn(100, 4).astype("float32")
+    w = np.random.randn(4, 3).astype("float32")
+    y = x @ w + 1
+    model.fit(x, y, batch_size=50, epochs=2, n_mc=5, eager=False)
+
+    # Check predictions
+    p = model.predict(x[:11, :])
+    assert isinstance(p, np.ndarray)
+    assert p.ndim == 2
+    assert p.shape[0] == 11
+    assert p.shape[1] == 3


### PR DESCRIPTION
* Add the `n_mc` kwarg to `probflow.Model.fit`, which sets the number of monte carlo samples which are taken per batch.  This performs parameter updates using average of the gradients across multiple MC samples per batch.  It's slower with more samples, but leads to more stable fitting.

Fixes https://github.com/brendanhasz/probflow/issues/21

- [x] add ability to use >1 MC sample ber batch (`n_mc` kwarg to `Model.fit`)
- [x] tests
- [x] update applications and modules to be compatible w/ >1 MC sample/batch
- [x] tests
- [x] add section to user guide about it