### PR TITLE
Add mixture distribution for pytorch

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.2
+current_version = 2.1.3
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as f:
 
 setup(
     name="probflow",
-    version="2.1.2",
+    version="2.1.3",
     author="Brendan Hasz",
     author_email="winsto99@gmail.com",
     description="A Python package for building Bayesian models with TensorFlow or PyTorch",

--- a/src/probflow/__init__.py
+++ b/src/probflow/__init__.py
@@ -9,4 +9,4 @@ from probflow.utils.base import *
 from probflow.utils.io import *
 from probflow.utils.settings import *
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/tests/unit/pytorch/distributions/test_mixture.py
+++ b/tests/unit/pytorch/distributions/test_mixture.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+import torch
+import torch.distributions as tod
+
+from probflow.distributions import Mixture, Normal
+
+
+def is_close(a, b, tol=1e-3):
+    return np.abs(a - b) < tol
+
+
+def test_Mixture():
+    """Tests Mixture distribution"""
+
+    # Should fail w incorrect args
+    with pytest.raises(ValueError):
+        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])))
+    with pytest.raises(TypeError):
+        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), "lala")
+    with pytest.raises(TypeError):
+        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), logits="lala")
+    with pytest.raises(TypeError):
+        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), probs="lala")
+    with pytest.raises(TypeError):
+        dist = Mixture("lala", probs=torch.randn([5, 3]))
+
+    # Create the distribution
+    weights = torch.randn([5, 3])
+    rands = torch.randn([5, 3])
+    dists = Normal(rands, torch.exp(rands))
+    dist = Mixture(dists, weights)
+
+    # Call should return backend obj
+    assert isinstance(dist(), tod.MixtureSameFamily)
+
+    # Test sampling
+    samples = dist.sample()
+    assert isinstance(samples, torch.Tensor)
+    assert samples.ndim == 1
+    assert samples.shape[0] == 5
+    samples = dist.sample(10)
+    assert isinstance(samples, torch.Tensor)
+    assert samples.ndim == 2
+    assert samples.shape[0] == 10
+    assert samples.shape[1] == 5
+
+    # Test methods
+    dist = Mixture(Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])), torch.tensor([0.5, 0.5]))
+    probs = dist.prob(torch.tensor([-1.0, 1.0]))
+    assert is_close(probs[0] / probs[1], 1.0)
+
+    dist = Mixture(
+        Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])),
+        torch.tensor(np.log(np.array([0.8, 0.2]).astype("float32"))),
+    )
+    probs = dist.prob(torch.tensor([-1.0, 1.0]))
+    assert is_close(probs[0] / probs[1], 4.0)
+
+    dist = Mixture(
+        Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])),
+        torch.tensor(np.log(np.array([0.1, 0.9]).astype("float32"))),
+    )
+    probs = dist.prob(torch.tensor([-1.0, 1.0]))
+    assert is_close(probs[0] / probs[1], 1.0 / 9.0)
+
+    # try w/ weight_type
+    dist = Mixture(
+        Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])),
+        logits=torch.tensor(np.log(np.array([0.1, 0.9]).astype("float32"))),
+    )
+    probs = dist.prob(torch.tensor([-1.0, 1.0]))
+    assert is_close(probs[0] / probs[1], 1.0 / 9.0)
+
+    dist = Mixture(
+        Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])),
+        probs=torch.tensor(np.array([0.1, 0.9]).astype("float32")),
+    )
+    probs = dist.prob(torch.tensor([-1.0, 1.0]))
+    assert is_close(probs[0] / probs[1], 1.0 / 9.0)

--- a/tests/unit/pytorch/distributions/test_mixture.py
+++ b/tests/unit/pytorch/distributions/test_mixture.py
@@ -17,11 +17,17 @@ def test_Mixture():
     with pytest.raises(ValueError):
         dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])))
     with pytest.raises(TypeError):
-        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), "lala")
+        dist = Mixture(
+            Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), "lala"
+        )
     with pytest.raises(TypeError):
-        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), logits="lala")
+        dist = Mixture(
+            Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), logits="lala"
+        )
     with pytest.raises(TypeError):
-        dist = Mixture(Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), probs="lala")
+        dist = Mixture(
+            Normal(torch.tensor([1, 2]), torch.tensor([1, 2])), probs="lala"
+        )
     with pytest.raises(TypeError):
         dist = Mixture("lala", probs=torch.randn([5, 3]))
 
@@ -46,7 +52,10 @@ def test_Mixture():
     assert samples.shape[1] == 5
 
     # Test methods
-    dist = Mixture(Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])), torch.tensor([0.5, 0.5]))
+    dist = Mixture(
+        Normal(torch.tensor([-1.0, 1.0]), torch.tensor([1e-3, 1e-3])),
+        torch.tensor([0.5, 0.5]),
+    )
     probs = dist.prob(torch.tensor([-1.0, 1.0]))
     assert is_close(probs[0] / probs[1], 1.0)
 

--- a/tests/unit/tensorflow/distributions/test_mixture.py
+++ b/tests/unit/tensorflow/distributions/test_mixture.py
@@ -24,6 +24,8 @@ def test_Mixture():
         dist = Mixture(Normal([1, 2], [1, 2]), logits="lala")
     with pytest.raises(TypeError):
         dist = Mixture(Normal([1, 2], [1, 2]), probs="lala")
+    with pytest.raises(TypeError):
+        dist = Mixture("lala", probs=tf.random.normal([5, 3]))
 
     # Create the distribution
     weights = tf.random.normal([5, 3])
@@ -46,7 +48,6 @@ def test_Mixture():
     assert samples.shape[1] == 5
 
     # Test methods
-
     dist = Mixture(Normal([-1.0, 1.0], [1e-3, 1e-3]), [0.5, 0.5])
     probs = dist.prob([-1.0, 1.0])
     assert is_close(probs[0] / probs[1], 1.0)


### PR DESCRIPTION
They've implemented a `MixtureSameFamily` distribution for PyTorch, so add the pytorch implementation for `probflow.distributions.Mixture` using that.

Fixes https://github.com/brendanhasz/probflow/issues/9