### PR TITLE
Change expected_calibration_error to calibration_metric

### DIFF
--- a/docs/examples/neural_linear.rst
+++ b/docs/examples/neural_linear.rst
@@ -270,8 +270,9 @@ Uncertainty calibration
 But is the neural linear model - a mostly non-Bayesian network - at all
 well-calibrated in terms of its uncertainty estimates?  We can measure the
 calibration of the model (how accurate its uncertainty estimates are) using
-calibration curves and the expected calibration error for regression (`Kuleshov
-et al., 2018 <https://arxiv.org/abs/1807.00263>`_).
+calibration curves and the mean squared calibration error for regression (see
+`Kuleshov et al., 2018 <https://arxiv.org/abs/1807.00263>`_ and `Chung et al.,
+2020 <https://arxiv.org/abs/2011.09588>`_).
 
 Essentially, the calibration curve plots the proportion of samples which our
 model predicts to have less than or equal to some cumulative probability,
@@ -283,15 +284,15 @@ percentile.  If the model is perfectly calibrated, these values will match, and
 we'll end up with a calibration curve which goes along the identity line from
 (0, 0) to (1, 1).
 
-Then, the expected calibration error is just a metric of how far our model's
-calibration deviates from the ideal calibration curve (i.e., what the
+Then, the mean squared calibration error is just a metric of how far our
+model's calibration deviates from the ideal calibration curve (i.e., what the
 calibration curve would be if the model were perfectly calibrated - the
 identity line).  Check out the docs for
-:meth:`.ContinuousModel.expected_calibration_error` for a more formal
-definition.
+:meth:`.ContinuousModel.calibration_metric` for a more formal definition (and
+for other calibration metrics we could have used).
 
 ProbFlow's :class:`.ContinuousModel` class has methods to compute both the
-calibration curve and the expected calibration error.  So, all we need to do to
+calibration curve and various calibration metrics.  So, all we need to do to
 view the calibration curve is:
 
 .. code-block:: python3
@@ -311,19 +312,19 @@ view the calibration curve is:
    :align: center
 
 Note that for :meth:`.ContinuousModel.calibration_curve_plot` above (and for
-:meth:`.ContinuousModel.expected_calibration_error` below) we're using the
+:meth:`.ContinuousModel.calibration_metric` below) we're using the
 ``batch_size`` keyword argument to perform the computation in batches.
 Otherwise, if we tried to run the calculation using all ~600,000 samples in the
 validation data as one single ginormous batch, we'd run out of memory!
 
-To view the expected calibration error, we can just use
-:meth:`.ContinuousModel.expected_calibration_error` (lower is better):
+To view the mean squared calibration error (MSCE), we can just use
+:meth:`.ContinuousModel.calibration_metric` (lower is better):
 
 .. code-block:: pycon
 
-    >>> nlm_model.expected_calibration_error(x_val, y_val, batch_size=10000)
+    >>> nlm_model.calibration_metric("msce", x_val, y_val, batch_size=10000)
     0.00307
-    >>> bnn_model.expected_calibration_error(x_val, y_val, batch_size=10000)
+    >>> bnn_model.calibration_metric("msce", x_val, y_val, batch_size=10000)
     0.00412
 
 Both the neural linear model and the fully Bayesian network have pretty good
@@ -343,8 +344,8 @@ References
 
 * Jasper Snoek, Oren Rippel, Kevin Swersky, Ryan Kiros, Nadathur Satish,
   Narayanan Sundaram, Md. Mostofa Ali Patwary, Prabhat, Ryan P. Adams.
-  `Scalable Bayesian Optimization Using Deep Neural
-  Networks <https://arxiv.org/abs/1502.05700>`_, 2015
+  `Scalable Bayesian Optimization Using Deep Neural Networks
+  <https://arxiv.org/abs/1502.05700>`_, 2015
 * Carlos Riquelme, George Tucker, and Jasper Snoek.
   `Deep Bayesian Bandits Showdown <https://arxiv.org/abs/1802.09127>`_, 2018
 * Sebastian W. Ober and Carl Edward Rasmussen.
@@ -356,4 +357,6 @@ References
 * Weilin Zhou and Frederic Precioso.
   `Adaptive Bayesian Linear Regression for Automated Machine Learning
   <https://arxiv.org/abs/1904.00577>`_, 2019
-
+* Youngseog Chung, Willie Neiswanger, Ian Char, Jeff Schneider.
+  `Beyond Pinball Loss: Quantile Methods for Calibrated Uncertainty
+  Quantification <https://arxiv.org/abs/2011.09588>`_, 2020

--- a/docs/user_guide/evaluating.rst
+++ b/docs/user_guide/evaluating.rst
@@ -3,6 +3,33 @@ Evaluating Model Performance
 
 .. include:: ../macros.hrst
 
-TODO: how to criticize the model w/ metrics, residuals, predictive_distribution,
-log_prob_by, pred_dist_covered, coverage_by, calibration_curve,
-r_squared, etc
+TODO: how to evaluate + criticize the model w/ ...
+
+Continuous Models
+-----------------
+
+TODO:
+
+* metric (only continuous ones)
+* r_squared
+* r_squared_plot
+* residuals
+* residuals_plot
+* calibration_curve
+* calibration_curve_plot
+* calibration_metric
+* sharpness
+* coefficient_of_variation
+* pred_dist_covered
+* pred_dist_coverage
+* coverage_by
+
+
+Categorical Models
+------------------
+
+TODO:
+
+* calibration_curve
+* calibration_curve_plot
+* calibration_metric

--- a/docs/user_guide/predicting.rst
+++ b/docs/user_guide/predicting.rst
@@ -4,3 +4,27 @@ Making Predictions with a Model
 .. include:: ../macros.hrst
 
 TODO: how to predict w/ MAP estimates and predictive distributions (predict, predictive_distribution, and plot_predictive_distribution)
+
+Any Model
+---------
+
+TODO: talk through how to use :class:`.Model`'s methods for prediction and sampling:
+
+* predict
+* log_prob / prob
+* predictive_sample
+* aleatoric_sample
+* epistemic_sample
+* pred_dist_plot
+
+Continuous Model
+----------------
+
+TODO: talk through how to use
+
+* predictive_interval
+* aleatoric_interval
+* epistemic_interval
+* pred_dist_plot
+* predictive_prc
+

--- a/tests/unit/pytorch/models/test_continuous_model.py
+++ b/tests/unit/pytorch/models/test_continuous_model.py
@@ -222,26 +222,71 @@ def test_ContinuousModel(plot):
     assert np.all(p_hat >= 0)
     assert np.all(p_hat <= 1)
 
-    # calibration curve
+    # calibration curve plot
     model.calibration_curve_plot(x, y, resolution=11)
     if plot:
         plt.title("should be calibration curve")
         plt.show()
 
-    # calibration curve (with batching)
+    # calibration curve plot (with batching)
     model.calibration_curve_plot(x, y, resolution=11, batch_size=25)
     if plot:
         plt.title("should be calibration curve (with batching)")
         plt.show()
 
-    # expected calibration error
-    ece = model.expected_calibration_error(x[:90, :], y[:90, :], resolution=11)
-    assert isinstance(ece, float)
-    assert ece >= 0
-
-    # expected calibration error
-    ece = model.expected_calibration_error(
-        x[:90, :], y[:90, :], resolution=11, batch_size=30
+    # calibration metrics: msce
+    msce = model.calibration_metric(
+        "msce", x[:90, :], y[:90, :], resolution=11
     )
-    assert isinstance(ece, float)
-    assert ece >= 0
+    assert isinstance(msce, float)
+    assert msce >= 0
+    assert msce <= 1
+
+    # calibration metrics: rmsce
+    rmsce = model.calibration_metric(
+        "rmsce", x[:90, :], y[:90, :], resolution=11
+    )
+    assert isinstance(rmsce, float)
+    assert rmsce >= 0
+    assert rmsce <= 1
+
+    # calibration metrics: mace
+    mace = model.calibration_metric(
+        "mace", x[:90, :], y[:90, :], resolution=11
+    )
+    assert isinstance(mace, float)
+    assert mace >= 0
+    assert mace <= 1
+
+    # calibration metrics: ma
+    ma = model.calibration_metric("ma", x[:90, :], y[:90, :], resolution=11)
+    assert isinstance(ma, float)
+    assert ma >= 0
+    assert ma <= 1
+
+    # should raise value error on invalid metric name
+    with pytest.raises(ValueError):
+        ma = model.calibration_metric(
+            "lala", x[:90, :], y[:90, :], resolution=11
+        )
+
+    # calibration metrics: list of em
+    metrics = model.calibration_metric(
+        ["mace", "ma"], x[:90, :], y[:90, :], resolution=11
+    )
+    assert isinstance(metrics, dict)
+    assert len(metrics) == 2
+    assert "mace" in metrics
+    assert "ma" in metrics
+    assert metrics["mace"] >= 0
+    assert metrics["mace"] <= 1
+    assert metrics["ma"] >= 0
+    assert metrics["ma"] <= 1
+
+    # calibration metric with batching
+    msce = model.calibration_metric(
+        "msce", x[:90, :], y[:90, :], resolution=11, batch_size=30
+    )
+    assert isinstance(msce, float)
+    assert msce >= 0
+    assert msce <= 1

--- a/tests/unit/pytorch/models/test_continuous_model.py
+++ b/tests/unit/pytorch/models/test_continuous_model.py
@@ -290,3 +290,41 @@ def test_ContinuousModel(plot):
     assert isinstance(msce, float)
     assert msce >= 0
     assert msce <= 1
+
+    # sharpness
+    sha = model.sharpness(x[:90, :])
+    assert isinstance(sha, (float, np.floating))
+    assert rmsce >= 0
+
+    # sharpness w/ batching
+    sha = model.sharpness(x[:90, :], batch_size=30)
+    assert isinstance(sha, (float, np.floating))
+    assert rmsce >= 0
+
+    # dispersion metric: cv
+    dm = model.dispersion_metric("cv", x[:90, :])
+    assert isinstance(dm, (float, np.floating))
+    assert dm >= 0
+
+    # dispersion metric: qcd
+    dm = model.dispersion_metric("qcd", x[:90, :])
+    assert isinstance(dm, (float, np.floating))
+    assert dm >= 0
+
+    # dispersion metric w/ batching
+    dm = model.dispersion_metric("cv", x[:90, :], batch_size=30)
+    assert isinstance(dm, (float, np.floating))
+    assert dm >= 0
+
+    # should raise value error on invalid metric name
+    with pytest.raises(ValueError):
+        dm = model.dispersion_metric("lala", x[:90, :])
+
+    # dispersion metrics: list of em
+    metrics = model.dispersion_metric(["cv", "qcd"], x[:90, :])
+    assert isinstance(metrics, dict)
+    assert len(metrics) == 2
+    assert "cv" in metrics
+    assert "qcd" in metrics
+    assert metrics["cv"] >= 0
+    assert metrics["qcd"] >= 0

--- a/tests/unit/tensorflow/models/test_continuous_model.py
+++ b/tests/unit/tensorflow/models/test_continuous_model.py
@@ -239,17 +239,62 @@ def test_ContinuousModel(plot):
         plt.title("should be calibration curve (with batching)")
         plt.show()
 
-    # expected calibration error
-    ece = model.expected_calibration_error(x[:90, :], y[:90, :], resolution=11)
-    assert isinstance(ece, float)
-    assert ece >= 0
-
-    # expected calibration error
-    ece = model.expected_calibration_error(
-        x[:90, :], y[:90, :], resolution=11, batch_size=30
+    # calibration metrics: msce
+    msce = model.calibration_metric(
+        "msce", x[:90, :], y[:90, :], resolution=11
     )
-    assert isinstance(ece, float)
-    assert ece >= 0
+    assert isinstance(msce, float)
+    assert msce >= 0
+    assert msce <= 1
+
+    # calibration metrics: rmsce
+    rmsce = model.calibration_metric(
+        "rmsce", x[:90, :], y[:90, :], resolution=11
+    )
+    assert isinstance(rmsce, float)
+    assert rmsce >= 0
+    assert rmsce <= 1
+
+    # calibration metrics: mace
+    mace = model.calibration_metric(
+        "mace", x[:90, :], y[:90, :], resolution=11
+    )
+    assert isinstance(mace, float)
+    assert mace >= 0
+    assert mace <= 1
+
+    # calibration metrics: ma
+    ma = model.calibration_metric("ma", x[:90, :], y[:90, :], resolution=11)
+    assert isinstance(ma, float)
+    assert ma >= 0
+    assert ma <= 1
+
+    # should raise value error on invalid metric name
+    with pytest.raises(ValueError):
+        ma = model.calibration_metric(
+            "lala", x[:90, :], y[:90, :], resolution=11
+        )
+
+    # calibration metrics: list of em
+    metrics = model.calibration_metric(
+        ["mace", "ma"], x[:90, :], y[:90, :], resolution=11
+    )
+    assert isinstance(metrics, dict)
+    assert len(metrics) == 2
+    assert "mace" in metrics
+    assert "ma" in metrics
+    assert metrics["mace"] >= 0
+    assert metrics["mace"] <= 1
+    assert metrics["ma"] >= 0
+    assert metrics["ma"] <= 1
+
+    # calibration metric with batching
+    msce = model.calibration_metric(
+        "msce", x[:90, :], y[:90, :], resolution=11, batch_size=30
+    )
+    assert isinstance(msce, float)
+    assert msce >= 0
+    assert msce <= 1
 
 
 def test_ContinuousModel_multivariate():

--- a/tests/unit/tensorflow/models/test_continuous_model.py
+++ b/tests/unit/tensorflow/models/test_continuous_model.py
@@ -292,9 +292,47 @@ def test_ContinuousModel(plot):
     msce = model.calibration_metric(
         "msce", x[:90, :], y[:90, :], resolution=11, batch_size=30
     )
-    assert isinstance(msce, float)
+    assert isinstance(msce, (float, np.floating))
     assert msce >= 0
     assert msce <= 1
+
+    # sharpness
+    sha = model.sharpness(x[:90, :])
+    assert isinstance(sha, (float, np.floating))
+    assert rmsce >= 0
+
+    # sharpness w/ batching
+    sha = model.sharpness(x[:90, :], batch_size=30)
+    assert isinstance(sha, (float, np.floating))
+    assert rmsce >= 0
+
+    # dispersion metric: cv
+    dm = model.dispersion_metric("cv", x[:90, :])
+    assert isinstance(dm, (float, np.floating))
+    assert dm >= 0
+
+    # dispersion metric: qcd
+    dm = model.dispersion_metric("qcd", x[:90, :])
+    assert isinstance(dm, (float, np.floating))
+    assert dm >= 0
+
+    # dispersion metric w/ batching
+    dm = model.dispersion_metric("cv", x[:90, :], batch_size=30)
+    assert isinstance(dm, (float, np.floating))
+    assert dm >= 0
+
+    # should raise value error on invalid metric name
+    with pytest.raises(ValueError):
+        dm = model.dispersion_metric("lala", x[:90, :])
+
+    # dispersion metrics: list of em
+    metrics = model.dispersion_metric(["cv", "qcd"], x[:90, :])
+    assert isinstance(metrics, dict)
+    assert len(metrics) == 2
+    assert "cv" in metrics
+    assert "qcd" in metrics
+    assert metrics["cv"] >= 0
+    assert metrics["qcd"] >= 0
 
 
 def test_ContinuousModel_multivariate():


### PR DESCRIPTION
Remove `expected_calibration_error`, and replace with a more general `calibration_metric`, which can compute any of several different calibration metrics (like mean squared calibration error, mean absolute calibration error, miscalibration area, etc).