### PR TITLE
Static posterior sampling

### DIFF
--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -842,7 +842,7 @@ class Model(Module):
 
         # Get a distribution of samples
         if distribution:
-            with Sampling():
+            with Sampling(n=1, flipout=False):
                 probs = []
                 for i in range(n):
                     t_probs = []

--- a/src/probflow/parameters/parameter.py
+++ b/src/probflow/parameters/parameter.py
@@ -9,7 +9,11 @@ from probflow.utils.base import BaseDistribution, BaseParameter
 from probflow.utils.casting import to_numpy
 from probflow.utils.initializers import scale_xavier, xavier
 from probflow.utils.plotting import plot_dist
-from probflow.utils.settings import Sampling, get_samples, get_static_sampling_uuid
+from probflow.utils.settings import (
+    Sampling,
+    get_samples,
+    get_static_sampling_uuid,
+)
 
 
 def cache_static_samples(fn):

--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -498,7 +498,7 @@ def reshape(x, new_shape):
 def copy_tensor(x):
     """Copy a tensor, detaching it from the gradient/backend/etc/etc"""
     if get_backend() == "pytorch":
-        import torch
+        pass
 
         return x.detach().clone()
     else:

--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -29,6 +29,7 @@ The utils.ops module contains operations which run using the current backend.
 * :func:`.insert_col_of`
 * :func:`.new_variable`
 * :func:`.log_cholesky_transform`
+* :func:`.copy_tensor`
 
 ----------
 
@@ -64,6 +65,7 @@ __all__ = [
     "insert_col_of",
     "new_variable",
     "log_cholesky_transform",
+    "copy_tensor",
 ]
 
 
@@ -491,3 +493,15 @@ def reshape(x, new_shape):
         import tensorflow as tf
 
         return tf.reshape(x, new_shape)
+
+
+def copy_tensor(x):
+    """Copy a tensor, detaching it from the gradient/backend/etc/etc"""
+    if get_backend() == "pytorch":
+        import torch
+
+        return x.detach().clone()
+    else:
+        import tensorflow as tf
+
+        return tf.identity(x)

--- a/src/probflow/utils/settings.py
+++ b/src/probflow/utils/settings.py
@@ -70,7 +70,6 @@ variational distributions while inside the context manager.
 
 import uuid
 
-
 __all__ = [
     "get_backend",
     "set_backend",

--- a/src/probflow/utils/settings.py
+++ b/src/probflow/utils/settings.py
@@ -45,6 +45,17 @@ Whether to use `Flipout <https://arxiv.org/abs/1803.04386>`_ where possible.
 * :func:`.set_flipout`
 
 
+Static posterior sampling
+-------------------------
+
+Whether or not to use static posterior sampling (i.e., take a random sample
+from the posterior, but take the same random sample on repeated calls), and
+control the UUID of the current static sampling regime.
+
+* :func:`.get_static_sampling_uuid`
+* :func:`.set_static_sampling_uuid`
+
+
 Sampling context manager
 ------------------------
 
@@ -66,6 +77,8 @@ __all__ = [
     "set_samples",
     "get_flipout",
     "set_flipout",
+    "get_static_sampling_uuid",
+    "set_static_sampling_uuid",
     "Sampling",
 ]
 
@@ -82,8 +95,10 @@ class _Settings:
         If |None|, will use MAP estimates.
     _FLIPOUT : bool
         Whether to use flipout where possible
-    _DATATYPE : tf.dtype or ???
+    _DATATYPE : tf.dtype or torch.dtype
         Default datatype to use for tensors
+    _STATIC_SAMPLING_UUID : None or uuid.UUID
+        UUID of the current static sampling regime
     """
 
     def __init__(self):
@@ -91,6 +106,7 @@ class _Settings:
         self._SAMPLES = None
         self._FLIPOUT = False
         self._DATATYPE = None
+        self._STATIC_SAMPLING_UUID = None
 
 
 # Global ProbFlow settings
@@ -224,6 +240,19 @@ def set_flipout(flipout):
         raise TypeError("flipout must be True or False")
 
 
+def get_static_sampling_uuid():
+    """Get the current static sampling UUID"""
+    return __SETTINGS__._STATIC_SAMPLING_UUID
+
+
+def set_static_sampling_uuid(uuid_value):
+    """Set the current static sampling UUID"""
+    if isinstance(uuid_value, uuid.UUID):
+        __SETTINGS__._STATIC_SAMPLING_UUID = uuid_value
+    else:
+        raise TypeError("must be a uuid")
+
+
 class Sampling:
     """Use sampling while within this context manager.
 
@@ -282,18 +311,44 @@ class Sampling:
          [ 3.5294306]
          [ 1.6596333]]
 
+    To use static samples - that is, to always return the same samples while in
+    the same context manager - use the sampling context manager with the
+    ``static`` keyword argument set to ``True``:
+
+    .. code-block:: pycon
+
+        >>> with pf.Sampling(static=True):
+        >>>     param()
+        [ 0.10457394]
+        >>>     param()  # repeated samples yield the same value
+        [ 0.10457394]
+        >>> with pf.Sampling(static=True):
+        >>>     param()  # under a new context manager they yield new samples
+        [-2.641631]
+        >>>     param()  # but remain the same while under the same context
+        [-2.641631]
+
     """
 
-    def __init__(self, n=1, flipout=False):
+    def __init__(self, n=None, flipout=None, static=None):
         self._n = n
         self._flipout = flipout
+        self._static = static
 
     def __enter__(self):
         """Begin sampling."""
-        set_samples(self._n)
-        set_flipout(self._flipout)
+        if self._n is not None:
+            set_samples(self._n)
+        if self._flipout is not None:
+            set_flipout(self._flipout)
+        if self._static is not None:
+            set_static_sampling_uuid(uuid.uuid4())
 
     def __exit__(self, _type, _val, _tb):
         """End sampling and reset sampling settings to defaults"""
-        set_samples(None)
-        set_flipout(False)
+        if self._n is not None:
+            set_samples(None)
+        if self._flipout is not None:
+            set_flipout(False)
+        if self._static is not None:
+            set_static_sampling_uuid(None)

--- a/src/probflow/utils/settings.py
+++ b/src/probflow/utils/settings.py
@@ -68,6 +68,9 @@ variational distributions while inside the context manager.
 """
 
 
+import uuid
+
+
 __all__ = [
     "get_backend",
     "set_backend",
@@ -247,10 +250,10 @@ def get_static_sampling_uuid():
 
 def set_static_sampling_uuid(uuid_value):
     """Set the current static sampling UUID"""
-    if isinstance(uuid_value, uuid.UUID):
+    if uuid_value is None or isinstance(uuid_value, uuid.UUID):
         __SETTINGS__._STATIC_SAMPLING_UUID = uuid_value
     else:
-        raise TypeError("must be a uuid")
+        raise TypeError("must be a uuid or None")
 
 
 class Sampling:

--- a/tests/unit/pytorch/modules/test_dense_network.py
+++ b/tests/unit/pytorch/modules/test_dense_network.py
@@ -33,7 +33,7 @@ def test_DenseNetwork():
     assert samples1.shape[1] == 2
 
     # Test samples are different
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
         samples2 = dense_net(x)
     assert np.all(samples1.detach().numpy() != samples2.detach().numpy())
@@ -71,7 +71,7 @@ def test_DenseNetwork():
     assert kl_loss.ndim == 0
 
     # test Flipout
-    with Sampling(flipout=True):
+    with Sampling(n=1, flipout=True):
         samples1 = dense_net(x)
         samples2 = dense_net(x)
     assert np.all(samples1.detach().numpy() != samples2.detach().numpy())
@@ -81,7 +81,7 @@ def test_DenseNetwork():
 
     # With probabilistic = False
     dense_net = DenseNetwork([5, 4, 3, 2], probabilistic=False)
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
         samples2 = dense_net(x)
     assert np.all(samples1.detach().numpy() == samples2.detach().numpy())
@@ -93,7 +93,7 @@ def test_DenseNetwork():
     dense_net = DenseNetwork(
         [5, 4, 3, 2], batch_norm=True, batch_norm_loc="after"
     )
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
     assert samples1.ndim == 2
     assert samples1.shape[0] == 7
@@ -103,7 +103,7 @@ def test_DenseNetwork():
     dense_net = DenseNetwork(
         [5, 4, 3, 2], batch_norm=True, batch_norm_loc="before"
     )
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
     assert samples1.ndim == 2
     assert samples1.shape[0] == 7

--- a/tests/unit/pytorch/parameters/test_parameter.py
+++ b/tests/unit/pytorch/parameters/test_parameter.py
@@ -79,6 +79,62 @@ def test_Parameter_scalar():
     assert sample2.shape[1] == 1
     assert np.all(sample1.detach().numpy() != sample2.detach().numpy())
 
+    # sampling statement should allow static samples
+    sample1 = param()
+    with Sampling(static=True):
+        with Sampling(n=1):
+            sample2 = param()
+            sample3 = param()
+    with Sampling(static=True):
+        with Sampling(n=1):
+            sample4 = param()
+            sample5 = param()
+    assert sample1.ndim == 1
+    assert sample2.ndim == 1
+    assert sample3.ndim == 1
+    assert sample4.ndim == 1
+    assert sample5.ndim == 1
+    assert sample1.shape[0] == 1
+    assert sample2.shape[0] == 1
+    assert sample3.shape[0] == 1
+    assert sample4.shape[0] == 1
+    assert sample5.shape[0] == 1
+    assert sample1.detach().numpy() != sample2.detach().numpy()
+    assert sample1.detach().numpy() != sample3.detach().numpy()
+    assert sample2.detach().numpy() == sample3.detach().numpy()
+    assert sample1.detach().numpy() != sample4.detach().numpy()
+    assert sample1.detach().numpy() != sample5.detach().numpy()
+    assert sample4.detach().numpy() == sample5.detach().numpy()
+    assert sample2.detach().numpy() != sample4.detach().numpy()
+
+    # sampling statement should allow static samples (and work w/ n>1)
+    with Sampling(static=True):
+        with Sampling(n=5):
+            sample1 = param()
+            sample2 = param()
+    with Sampling(static=True):
+        with Sampling(n=5):
+            sample3 = param()
+            sample4 = param()
+    assert sample1.ndim == 2
+    assert sample2.ndim == 2
+    assert sample3.ndim == 2
+    assert sample4.ndim == 2
+    assert sample1.shape[0] == 5
+    assert sample1.shape[1] == 1
+    assert sample2.shape[0] == 5
+    assert sample2.shape[1] == 1
+    assert sample3.shape[0] == 5
+    assert sample3.shape[1] == 1
+    assert sample4.shape[0] == 5
+    assert sample4.shape[1] == 1
+    assert np.all(sample1.detach().numpy() == sample2.detach().numpy())
+    assert np.all(sample1.detach().numpy() != sample3.detach().numpy())
+    assert np.all(sample1.detach().numpy() != sample4.detach().numpy())
+    assert np.all(sample2.detach().numpy() != sample3.detach().numpy())
+    assert np.all(sample2.detach().numpy() != sample4.detach().numpy())
+    assert np.all(sample3.detach().numpy() == sample4.detach().numpy())
+
     # kl_loss should return sum of kl divergences
     kl_loss = param.kl_loss()
     assert isinstance(kl_loss, torch.Tensor)

--- a/tests/unit/pytorch/parameters/test_parameter.py
+++ b/tests/unit/pytorch/parameters/test_parameter.py
@@ -58,7 +58,7 @@ def test_Parameter_scalar():
     assert sample1.detach().numpy() == sample2.detach().numpy()
 
     # within a Sampling statement, should randomly sample from the dist
-    with Sampling():
+    with Sampling(n=1):
         sample1 = param()
         sample2 = param()
     assert sample1.ndim == 1

--- a/tests/unit/tensorflow/modules/test_dense.py
+++ b/tests/unit/tensorflow/modules/test_dense.py
@@ -36,7 +36,7 @@ def test_Dense():
     assert samples1.shape[1] == 1
 
     # Test samples are different
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense(x)
         samples2 = dense(x)
     assert np.all(samples1.numpy() != samples2.numpy())
@@ -63,7 +63,7 @@ def test_Dense():
     assert kl_loss.ndim == 0
 
     # test Flipout
-    with Sampling(flipout=True):
+    with Sampling(n=1, flipout=True):
         samples1 = dense(x)
         samples2 = dense(x)
     assert np.all(samples1.numpy() != samples2.numpy())
@@ -73,7 +73,7 @@ def test_Dense():
 
     # With the probabilistic kwarg
     dense = Dense(5, 3, probabilistic=False)
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense(x)
         samples2 = dense(x)
     assert np.all(samples1.numpy() == samples2.numpy())
@@ -85,7 +85,7 @@ def test_Dense():
     weight_kwargs = {"transform": tf.exp}
     bias_kwargs = {"transform": tf.math.softplus}
     dense = Dense(5, 2, weight_kwargs=weight_kwargs, bias_kwargs=bias_kwargs)
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense(x)
         samples2 = dense(x)
     assert np.all(samples1.numpy() != samples2.numpy())

--- a/tests/unit/tensorflow/modules/test_dense_network.py
+++ b/tests/unit/tensorflow/modules/test_dense_network.py
@@ -36,7 +36,7 @@ def test_DenseNetwork():
     assert samples1.shape[1] == 2
 
     # Test samples are different
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
         samples2 = dense_net(x)
     assert np.all(samples1.numpy() != samples2.numpy())
@@ -74,7 +74,7 @@ def test_DenseNetwork():
     assert kl_loss.ndim == 0
 
     # test Flipout
-    with Sampling(flipout=True):
+    with Sampling(n=1, flipout=True):
         samples1 = dense_net(x)
         samples2 = dense_net(x)
     assert np.all(samples1.numpy() != samples2.numpy())
@@ -84,7 +84,7 @@ def test_DenseNetwork():
 
     # With probabilistic = False
     dense_net = DenseNetwork([5, 4, 3, 2], probabilistic=False)
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
         samples2 = dense_net(x)
     assert np.all(samples1.numpy() == samples2.numpy())
@@ -96,7 +96,7 @@ def test_DenseNetwork():
     dense_net = DenseNetwork(
         [5, 4, 3, 2], batch_norm=True, batch_norm_loc="after"
     )
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
     assert samples1.ndim == 2
     assert samples1.shape[0] == 7
@@ -106,7 +106,7 @@ def test_DenseNetwork():
     dense_net = DenseNetwork(
         [5, 4, 3, 2], batch_norm=True, batch_norm_loc="before"
     )
-    with Sampling():
+    with Sampling(n=1):
         samples1 = dense_net(x)
     assert samples1.ndim == 2
     assert samples1.shape[0] == 7

--- a/tests/unit/tensorflow/modules/test_embedding.py
+++ b/tests/unit/tensorflow/modules/test_embedding.py
@@ -48,7 +48,7 @@ def test_Embedding():
     assert samples1.shape[1] == 5
 
     # Samples should actually be the same b/c using deterministic posterior
-    with Sampling():
+    with Sampling(n=1):
         samples1 = emb(x)
         samples2 = emb(x)
     assert np.all(samples1.numpy() == samples2.numpy())
@@ -85,7 +85,7 @@ def test_Embedding():
     # With probabilistic = True, samples should be different
     emb = Embedding(10, 5, probabilistic=True)
     x = tf.random.uniform([20, 1], minval=0, maxval=9, dtype=tf.dtypes.int32)
-    with Sampling():
+    with Sampling(n=1):
         samples1 = emb(x)
         samples2 = emb(x)
     assert np.all(samples1.numpy() != samples2.numpy())

--- a/tests/unit/tensorflow/modules/test_module.py
+++ b/tests/unit/tensorflow/modules/test_module.py
@@ -69,7 +69,7 @@ def test_Module():
     assert np.all(sample1.numpy() == sample2.numpy())
 
     # outputs should be different when sampling is on
-    with Sampling():
+    with Sampling(n=1):
         sample1 = the_module(x)
         sample2 = the_module(x)
     assert np.all(sample1.numpy() != sample2.numpy())

--- a/tests/unit/tensorflow/modules/test_sequential.py
+++ b/tests/unit/tensorflow/modules/test_sequential.py
@@ -35,7 +35,7 @@ def test_Sequential():
     assert samples1.shape[1] == 1
 
     # Test samples are different
-    with Sampling():
+    with Sampling(n=1):
         samples1 = seq(x)
         samples2 = seq(x)
     assert np.all(samples1.numpy() != samples2.numpy())

--- a/tests/unit/tensorflow/parameters/test_parameter.py
+++ b/tests/unit/tensorflow/parameters/test_parameter.py
@@ -61,7 +61,7 @@ def test_Parameter_scalar():
     assert sample1.numpy() == sample2.numpy()
 
     # within a Sampling statement, should randomly sample from the dist
-    with Sampling():
+    with Sampling(n=1):
         sample1 = param()
         sample2 = param()
     assert sample1.ndim == 1

--- a/tests/unit/tensorflow/parameters/test_parameter.py
+++ b/tests/unit/tensorflow/parameters/test_parameter.py
@@ -82,6 +82,62 @@ def test_Parameter_scalar():
     assert sample2.shape[1] == 1
     assert np.all(sample1.numpy() != sample2.numpy())
 
+    # sampling statement should allow static samples
+    sample1 = param()
+    with Sampling(static=True):
+        with Sampling(n=1):
+            sample2 = param()
+            sample3 = param()
+    with Sampling(static=True):
+        with Sampling(n=1):
+            sample4 = param()
+            sample5 = param()
+    assert sample1.ndim == 1
+    assert sample2.ndim == 1
+    assert sample3.ndim == 1
+    assert sample4.ndim == 1
+    assert sample5.ndim == 1
+    assert sample1.shape[0] == 1
+    assert sample2.shape[0] == 1
+    assert sample3.shape[0] == 1
+    assert sample4.shape[0] == 1
+    assert sample5.shape[0] == 1
+    assert sample1.numpy() != sample2.numpy()
+    assert sample1.numpy() != sample3.numpy()
+    assert sample2.numpy() == sample3.numpy()
+    assert sample1.numpy() != sample4.numpy()
+    assert sample1.numpy() != sample5.numpy()
+    assert sample4.numpy() == sample5.numpy()
+    assert sample2.numpy() != sample4.numpy()
+
+    # sampling statement should allow static samples (and work w/ n>1)
+    with Sampling(static=True):
+        with Sampling(n=5):
+            sample1 = param()
+            sample2 = param()
+    with Sampling(static=True):
+        with Sampling(n=5):
+            sample3 = param()
+            sample4 = param()
+    assert sample1.ndim == 2
+    assert sample2.ndim == 2
+    assert sample3.ndim == 2
+    assert sample4.ndim == 2
+    assert sample1.shape[0] == 5
+    assert sample1.shape[1] == 1
+    assert sample2.shape[0] == 5
+    assert sample2.shape[1] == 1
+    assert sample3.shape[0] == 5
+    assert sample3.shape[1] == 1
+    assert sample4.shape[0] == 5
+    assert sample4.shape[1] == 1
+    assert np.all(sample1.numpy() == sample2.numpy())
+    assert np.all(sample1.numpy() != sample3.numpy())
+    assert np.all(sample1.numpy() != sample4.numpy())
+    assert np.all(sample2.numpy() != sample3.numpy())
+    assert np.all(sample2.numpy() != sample4.numpy())
+    assert np.all(sample3.numpy() == sample4.numpy())
+
     # kl_loss should return sum of kl divergences
     kl_loss = param.kl_loss()
     assert isinstance(kl_loss, tf.Tensor)

--- a/tests/unit/tensorflow/utils/test_settings.py
+++ b/tests/unit/tensorflow/utils/test_settings.py
@@ -74,7 +74,7 @@ def test_samples():
 def test_flipout():
     """Tests setting and getting the flipout setting"""
 
-    # Default should be None
+    # Default should be False
     assert settings.get_flipout() is False
 
     # Should be able to change to True or False
@@ -90,6 +90,29 @@ def test_flipout():
         settings.set_flipout(1)
     with pytest.raises(TypeError):
         settings.set_flipout("lalala")
+
+
+def test_flipout():
+    """Tests setting and getting the static sampling uuid"""
+
+    # Default should be None
+    assert settings.get_static_sampling_uuid() is None
+
+    # Should be able to change to True or False
+    the_uuid = uuid.uuid4()
+    settings.set_static_sampling_uuid(the_uuid)
+    assert settings.get_static_sampling_uuid() is not None
+    assert settings.get_static_sampling_uuid() == the_uuid
+    settings.set_static_sampling_uuid(None)
+    assert settings.get_static_sampling_uuid() is None
+
+    # But only None or uuid
+    with pytest.raises(TypeError):
+        settings.set_static_sampling_uuid(3.14)
+    with pytest.raises(TypeError):
+        settings.set_static_sampling_uuid(1)
+    with pytest.raises(TypeError):
+        settings.set_static_sampling_uuid("lalala")
 
 
 def test_sampling():

--- a/tests/unit/tensorflow/utils/test_settings.py
+++ b/tests/unit/tensorflow/utils/test_settings.py
@@ -92,7 +92,7 @@ def test_flipout():
         settings.set_flipout("lalala")
 
 
-def test_flipout():
+def test_static_sampling_uuid():
     """Tests setting and getting the static sampling uuid"""
 
     # Default should be None


### PR DESCRIPTION
This adds what I'm calling "static posterior sampling" (can't think of a better name for it... I believe Pyro calls it "interception", but that's even less clear...).  Basically, it lets you take repeated random samples from the posterior - but they're the same random sample!  For example, normally getting posterior samples gets you, you know, *samples* (i.e. they're different):

```python
param = pf.Parameter()
x1 = param.posterior_sample()
x2 = param.posterior_sample()
assert x1 != x2  # they're not the same!  obviously!
```

But using the new `pf.Sampling(static=True)` context manager:

```python
x1 = param.posterior_sample()
with pf.Sampling(static=True):
    x2 = param.posterior_sample()
    x3 = param.posterior_sample()
assert x1 != x2  # we are taking a random sample (i.e. it's different from MAP)
assert x2 == x3  # but those samples are the same w/i context manager!
```

This was inspired by some reinforcement learning applications: when we're doing Thompson sampling, we want to take the *same* posterior sample over the course of a trial, even though we have to take multiple samples and can't just do it in one big batch (b/c we have to take the sample, then run the environment simulation / actually see what happens before taking the next sample).  For example,

```python
for i in range(n_trials):

    # Take the same posterior sample at each timestep in this trial
    # even though we're calling epistemic_sample multiple times!
    with pf.Sampling(static=True):

        for t in range(n_timesteps):

            r_hat = model.epistemic_sample(state_action_pairs)

            # select action w/ best r_hat

            # update state/reward according to action

    # update model
```