### PR TITLE
Add adjustable learning rate for PyTorch

### DIFF
--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -393,6 +393,9 @@ class Model(Module):
             raise TypeError("lr must be a float")
         else:
             self._learning_rate = lr
+        if get_backend() == "pytorch":
+            for g in self._optimizer.param_groups:
+                g["lr"] = self._learning_rate
 
     def set_kl_weight(self, w):
         """Set the weight of the KL term's contribution to the ELBO loss"""

--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -320,13 +320,10 @@ class Model(Module):
             if get_backend() == "pytorch":
                 import torch
 
-                self._optimizer = torch.optim.LambdaLR(
-                    torch.optim.Adam(
-                        self.trainable_variables,
-                        lr=self._learning_rate,
-                        **optimizer_kwargs
-                    ),
-                    lr_lambda=lambda: self._learning_rate,
+                self._optimizer = torch.optim.Adam(
+                    self.trainable_variables,
+                    lr=self._learning_rate,
+                    **optimizer_kwargs
                 )
             else:
                 import tensorflow as tf

--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -320,10 +320,13 @@ class Model(Module):
             if get_backend() == "pytorch":
                 import torch
 
-                self._optimizer = torch.optim.Adam(
-                    self.trainable_variables,
-                    lr=self._learning_rate,
-                    **optimizer_kwargs
+                self._optimizer = torch.optim.LambdaLR(
+                    torch.optim.Adam(
+                        self.trainable_variables,
+                        lr=self._learning_rate,
+                        **optimizer_kwargs
+                    ),
+                    lr_lambda=lambda: self._learning_rate,
                 )
             else:
                 import tensorflow as tf

--- a/tests/unit/pytorch/callbacks/test_learning_rate_scheduler.py
+++ b/tests/unit/pytorch/callbacks/test_learning_rate_scheduler.py
@@ -22,6 +22,8 @@ def test_LearningRateScheduler(plot):
     assert isinstance(lrs.learning_rate, list)
     assert len(lrs.learning_rate) == 10
     assert my_model._learning_rate == 1e-3
+    for g in my_model._optimizer.param_groups:
+        assert g["lr"] == 1e-3  # check optmizer is actually updating
     lrs.plot()
     if plot:
         plt.show()


### PR DESCRIPTION
This allows the learning rate (for the default optimizer) to be adjusted mid-training for PyTorch.

Fixes https://github.com/brendanhasz/probflow/issues/10