### PR TITLE
Update subplot indexes to ints

### DIFF
--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -756,7 +756,7 @@ class Model(Module):
             param_list = self.parameters
         else:
             param_list = [p for p in self.parameters if p.name in params]
-        rows = np.ceil(len(param_list) / cols)
+        rows = int(np.ceil(len(param_list) / cols))
         for iP in range(len(param_list)):
             plt.subplot(rows, cols, iP + 1)
             func(param_list[iP])


### PR DESCRIPTION
Getting

MatplotlibDeprecationWarning: Passing non-integers as three-element position specification is deprecated since 3.3 and will be removed two minor releases later.

b/c trying to pass non-integers as rows to plt.subplot.  This PR just casts em all to int where needed.