### PR TITLE
Fix rand_rademacher for pytorch backend

### DIFF
--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -184,11 +184,11 @@ def randn(shape):
 
 
 def rand_rademacher(shape):
-    """Tensor full of random 0s or 1s (i.e. drawn from a Rademacher dist)."""
+    """Tensor full of random -1s or 1s (i.e. drawn from a Rademacher dist)."""
     if get_backend() == "pytorch":
         import torch
 
-        return 2 * torch.randint(0, 1, shape, dtype=get_datatype()) - 1
+        return 2 * torch.randint(0, 2, shape, dtype=get_datatype()) - 1
     else:
         import tensorflow_probability as tfp
 


### PR DESCRIPTION
Hi, I noticed there was a problem where the rademacher distribution was implemented incorrectly for the pytorch backend. It was always returning `-1`. It now generates `-1` and `1` correctly just like for the tensorflow backend.

Edit: `test_rand_rademacher` was always passing because it always generated `-1`. It is not immediately obvious to me why other seemingly unreleated tests are failing now. I might look into it again when I get the time.