### PR TITLE
Fix PyTorch Gamma / InverseGamma

### DIFF
--- a/tests/unit/pytorch/distributions/test_gamma.py
+++ b/tests/unit/pytorch/distributions/test_gamma.py
@@ -25,11 +25,11 @@ def test_Gamma():
     assert isinstance(dist(), tod.gamma.Gamma)
 
     # Test methods
-    zero = torch.zeros([1])
+    zero = torch.zeros([1]) + 1e-5
     one = torch.ones([1])
     assert is_close(dist.prob(zero).numpy(), 0.0)
     assert is_close(dist.prob(one).numpy(), 0.78146726)
-    assert dist.log_prob(zero).numpy() == -np.inf
+    assert dist.log_prob(zero).numpy() < -10
     assert is_close(dist.log_prob(one).numpy(), np.log(0.78146726))
     assert is_close(dist.mean(), 5.0 / 4.0)
 

--- a/tests/unit/pytorch/distributions/test_inverse_gamma.py
+++ b/tests/unit/pytorch/distributions/test_inverse_gamma.py
@@ -41,8 +41,9 @@ def test_InverseGamma():
     assert samples.ndim == 1
     samples = dist.sample(10)
     assert isinstance(samples, torch.Tensor)
-    assert samples.ndim == 1
+    assert samples.ndim == 2
     assert samples.shape[0] == 10
+    assert samples.shape[1] == 1
 
     # Should be able to set params
     dist = InverseGamma(3, 2)

--- a/tests/unit/pytorch/parameters/test_centered_parameter.py
+++ b/tests/unit/pytorch/parameters/test_centered_parameter.py
@@ -235,7 +235,7 @@ def test_CenteredParameter_fit():
     x = np.random.randn(N, Di).astype("float32")
     w = np.random.randn(Di, Do).astype("float32")
     y = x @ w + 0.1 * np.random.randn(N, Do)
-    y = (1/(1+np.exp(-y)) > np.random.rand(N, Do)).astype('float32')
+    y = (1 / (1 + np.exp(-y)) > np.random.rand(N, Do)).astype("float32")
 
     model = MyModel(Di, Do)
 

--- a/tests/unit/pytorch/parameters/test_centered_parameter.py
+++ b/tests/unit/pytorch/parameters/test_centered_parameter.py
@@ -234,7 +234,8 @@ def test_CenteredParameter_fit():
     Do = 3
     x = np.random.randn(N, Di).astype("float32")
     w = np.random.randn(Di, Do).astype("float32")
-    y = x @ w + 0.1 * np.random.randn(N, Do).astype("float32")
+    y = x @ w + 0.1 * np.random.randn(N, Do)
+    y = (1/(1+np.exp(-y)) > np.random.rand(N, Do)).astype('float32')
 
     model = MyModel(Di, Do)
 


### PR DESCRIPTION
Looks like lower bound for inputs to PyTorch's Gamma distribution is now 0 exclusive?  And also an unexpected shape difference... (`sample(10)` appears to now return a 2D matrix instead of a 1D vector?).  

Tests which are failing / this PR fixes:

- [x] pytorch/distributions/test_gamma.py
- [x] pytorch/distributions/test_inverse_gamma.py
- [x] pytorch/parameters/test_centered_parameter.py