### PR TITLE
Don't check_trace in torch.jit.trace_module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
         flake8 src/probflow tests
     - name: Style checks with black
       run: |
-        black --check src/probflow tests
+        black --diff --check src/probflow tests
     - name: Run tests
       run: |
         pytest tests/unit/${{ matrix.backend }} --cov=probflow --cov-report xml:coverage.xml

--- a/src/probflow/models/categorical_model.py
+++ b/src/probflow/models/categorical_model.py
@@ -96,7 +96,7 @@ class CategoricalModel(Model):
             samples = samples.reshape([Ns, N])
 
         # Plot the predictive distributions
-        rows = np.ceil(N / cols)
+        rows = int(np.ceil(N / cols))
         for i in range(N):
             plt.subplot(rows, cols, i + 1)
             plot_categorical_dist(samples[:, i])

--- a/src/probflow/models/continuous_model.py
+++ b/src/probflow/models/continuous_model.py
@@ -302,7 +302,7 @@ class ContinuousModel(Model):
 
         # Plot the predictive distributions
         if individually:
-            rows = np.ceil(N / cols)
+            rows = int(np.ceil(N / cols))
             for i in range(N):
                 plt.subplot(rows, cols, i + 1)
                 plot_dist(samples[:, i], **kwargs)

--- a/src/probflow/models/discrete_model.py
+++ b/src/probflow/models/discrete_model.py
@@ -105,7 +105,7 @@ class DiscreteModel(ContinuousModel):
             samples = samples.reshape([Ns, N])
 
         # Plot the predictive distributions
-        rows = np.ceil(N / cols)
+        rows = int(np.ceil(N / cols))
         for i in range(N):
             plt.subplot(rows, cols, i + 1)
             plot_discrete_dist(samples[:, i])

--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -188,7 +188,9 @@ class Model(Module):
                     else:
                         m = PyTorchModule(self.model)
                         inputs = {"elbo_loss": args}
-                        self.fns[shape] = torch.jit.trace_module(m, inputs, check_trace=False)
+                        self.fns[shape] = torch.jit.trace_module(
+                            m, inputs, check_trace=False
+                        )
                         return self.fns[shape]
 
                 def __call__(self, *args):

--- a/src/probflow/models/model.py
+++ b/src/probflow/models/model.py
@@ -188,7 +188,7 @@ class Model(Module):
                     else:
                         m = PyTorchModule(self.model)
                         inputs = {"elbo_loss": args}
-                        self.fns[shape] = torch.jit.trace_module(m, inputs)
+                        self.fns[shape] = torch.jit.trace_module(m, inputs, check_trace=False)
                         return self.fns[shape]
 
                 def __call__(self, *args):

--- a/src/probflow/utils/ops.py
+++ b/src/probflow/utils/ops.py
@@ -296,7 +296,7 @@ def abs(val):
 def square(val):
     """Power of 2"""
     if get_backend() == "pytorch":
-        return val ** 2
+        return val**2
     else:
         import tensorflow as tf
 


### PR DESCRIPTION
PyTorch started enforcing a check that the output of a traced function matches the output of the same function eagerly-executed.  This will almost always fail in probflow applications, because most model's outputs will be different between two calls, because of the random posterior sampling.

To fix, we'll just set `check_trace=False` in `torch.jit.trace_module`.